### PR TITLE
include the netlify identity widget

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -8,5 +8,8 @@
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
   <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+  <!-- include the widget -->
+  <script type="text/javascript" src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+  
 </body>
 </html>


### PR DESCRIPTION
Hi Donovan! We forgot to actually add the netlify identity widget - required for guest credentials and authentication.